### PR TITLE
fix selinux denied

### DIFF
--- a/sepolicy/mediaserver.te
+++ b/sepolicy/mediaserver.te
@@ -17,3 +17,4 @@ allow mediaserver sysfs_wake_lock:file {read open write};
 allow mediaserver mmgr_socket:sock_file {write};
 allow mediaserver mmgr:unix_stream_socket {connectto};
 allow mediaserver tty_device:chr_file {read open ioctl write getattr};
+allow mediaserver default_prop:property_service set;


### PR DESCRIPTION
<12>[   19.920495] avc:  denied  { set } for property=media.camera.facing scontext=u:r:mediaserver:s0 tcontext=u:object_r:default_prop:s0 tclass=property_service
